### PR TITLE
Set ChatMessageReadStatus color to brand

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusStyles.ts
@@ -9,6 +9,7 @@ export const chatMessageReadStatusStyles: ComponentSlotStylesPrepared<
   ChatMessageReadStatusVariables
 > = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    color: v.color,
     position: 'absolute',
     right: p.density === 'compact' ? v.rightPositionCompact : v.rightPosition,
     bottom: p.density === 'compact' ? v.bottomPositionCompact : v.bottomPosition,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusVariables.ts
@@ -3,6 +3,7 @@ import { pxToRem } from '../../../../utils';
 export interface ChatMessageReadStatusVariables {
   bottomPosition?: string;
   bottomPositionCompact: string;
+  color?: string;
   rightPosition?: string;
   rightPositionCompact: string;
 }
@@ -10,6 +11,7 @@ export interface ChatMessageReadStatusVariables {
 export const chatMessageReadStatusVariables = (siteVars): ChatMessageReadStatusVariables => ({
   bottomPosition: pxToRem(0),
   bottomPositionCompact: pxToRem(2),
+  color: siteVars.colorScheme.brand.foreground1,
   rightPosition: pxToRem(-24),
   rightPositionCompact: pxToRem(-16),
 });


### PR DESCRIPTION
Change color of the ChatMessageReadStatus to brand foreground to match usage in Teams.
![image](https://user-images.githubusercontent.com/2564094/137647192-fb59f326-dd79-408b-a5e8-afeaa9e694a2.png)
![image](https://user-images.githubusercontent.com/2564094/137647206-284a8927-ceb7-421a-8333-9d04efea0c69.png)
