### PR TITLE
Set default focus border radius

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertDismissActionStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertDismissActionStyles.ts
@@ -25,16 +25,7 @@ export const alertDismissActionStyles: ComponentSlotStylesPrepared<AlertDismissA
     const { borderWidth } = siteVariables;
     const { color: dismissActionIndicatorColor } = getIntentColorsFromProps(p, v);
 
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: {
-        borderRadius: v.focusBorderRadius,
-        borderWidth: v.focusBorderWidth,
-        focusInnerBorderColor: v.focusInnerBorderColor,
-        focusOuterBorderColor: v.focusOuterBorderColor,
-        zIndexes: { foreground: v.focusBorderZIndex },
-      },
-      borderPadding: borderWidth,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables, borderPadding: borderWidth });
 
     return {
       height: v.dismissActionSize,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertVariables.ts
@@ -77,12 +77,6 @@ export interface AlertVariables {
   dismissActionBorderColorDisabled: string;
 
   dismissActionIndicatorSize: string;
-
-  focusBorderRadius: string;
-  focusBorderWidth: string;
-  focusInnerBorderColor: string;
-  focusOuterBorderColor: string;
-  focusBorderZIndex: string;
 }
 
 export const alertVariables = (siteVars: SiteVariablesPrepared): AlertVariables => {
@@ -162,11 +156,5 @@ export const alertVariables = (siteVars: SiteVariablesPrepared): AlertVariables 
     dismissActionBorderColorDisabled: 'transparent',
 
     dismissActionIndicatorSize: pxToRem(16),
-
-    focusBorderRadius: siteVars.borderRadiusMedium,
-    focusBorderWidth: siteVars.borderWidth,
-    focusInnerBorderColor: siteVars.focusInnerBorderColor,
-    focusOuterBorderColor: siteVars.focusOuterBorderColor,
-    focusBorderZIndex: siteVars.zIndexes.foreground,
   };
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentActionStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentActionStyles.ts
@@ -11,10 +11,7 @@ export const attachmentActionStyles: ComponentSlotStylesPrepared<AttachmentActio
   root: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
     const { siteVariables } = theme;
     const iconFilledStyles = getIconFillOrOutlineStyles({ outline: false });
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: siteVariables,
-      borderRadius: v.actionFocusBorderRadius,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables });
 
     return {
       height: v.actionHeight,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentStyles.ts
@@ -11,7 +11,6 @@ export const attachmentStyles: ComponentSlotStylesPrepared<AttachmentStylesProps
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
     const borderFocusStyles = getBorderFocusStyles({
       variables: siteVariables,
-      borderRadius: v.borderRadius,
     });
 
     return {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentVariables.ts
@@ -37,7 +37,6 @@ export type AttachmentVariables = {
   actionLoaderSize: string;
   actionLoaderSvgHeight: string;
   actionLoaderSvgAnimationHeight: string;
-  actionFocusBorderRadius: string;
 };
 
 export const attachmentVariables = (siteVariables: any): AttachmentVariables => ({
@@ -77,5 +76,4 @@ export const attachmentVariables = (siteVariables: any): AttachmentVariables => 
   actionLoaderSize: pxToRem(20),
   actionLoaderSvgHeight: pxToRem(1220),
   actionLoaderSvgAnimationHeight: pxToRem(-1200),
-  actionFocusBorderRadius: siteVariables.borderRadiusMedium,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -15,7 +15,6 @@ export const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, Button
 
     const borderFocusStyles = getBorderFocusStyles({
       variables: siteVariables,
-      borderRadius: siteVariables.borderRadiusMedium,
       borderPadding: borderWidth,
       ...(p.circular && {
         borderPadding: pxToRem(4),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardStyles.ts
@@ -8,10 +8,7 @@ export const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariab
   root: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
     const { siteVariables } = theme;
 
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: siteVariables,
-      borderRadius: v.borderRadius,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables });
 
     return {
       display: 'flex',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Carousel/carouselPaddleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Carousel/carouselPaddleStyles.ts
@@ -25,16 +25,7 @@ export const carouselPaddleStyles: ComponentSlotStylesPrepared<CarouselPaddleSty
     const { siteVariables } = theme;
     const { borderWidth } = siteVariables;
 
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: {
-        borderRadius: v.focusBorderRadius,
-        borderWidth: v.focusBorderWidth,
-        focusInnerBorderColor: v.focusInnerBorderColor,
-        focusOuterBorderColor: v.focusOuterBorderColor,
-        zIndexes: { foreground: v.focusBorderZIndex },
-      },
-      borderPadding: borderWidth,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables, borderPadding: borderWidth });
 
     return {
       height: v.paddleHeight,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Carousel/carouselVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Carousel/carouselVariables.ts
@@ -22,11 +22,6 @@ export interface CarouselVariables {
   paddleHeight: string;
 
   paddleIndicatorSize: string;
-
-  focusBorderRadius: string;
-  focusBorderWidth: string;
-  focusInnerBorderColor: string;
-  focusBorderZIndex: string;
 }
 
 export const carouselVariables = (siteVars): CarouselVariables => ({
@@ -51,9 +46,4 @@ export const carouselVariables = (siteVars): CarouselVariables => ({
   paddleHeight: pxToRem(32),
 
   paddleIndicatorSize: pxToRem(16),
-
-  focusBorderRadius: siteVars.borderRadiusMedium,
-  focusBorderWidth: siteVars.borderWidth,
-  focusInnerBorderColor: siteVars.focusInnerBorderColor,
-  focusBorderZIndex: siteVars.zIndexes.foreground,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxStyles.ts
@@ -37,7 +37,7 @@ export const checkboxStyles: ComponentSlotStylesPrepared<CheckboxStylesProps, Ch
     verticalAlign: 'middle',
     alignItems: 'start',
 
-    ...getBorderFocusStyles({ variables: t.siteVariables, borderRadius: '3px' }),
+    ...getBorderFocusStyles({ variables: t.siteVariables }),
 
     ':hover': {
       color: v.textColorHover,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemStyles.ts
@@ -36,9 +36,7 @@ const selectedStyle = variables => ({
 
 export const listItemStyles: ComponentSlotStylesPrepared<ListItemStylesProps, ListItemVariables> = {
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: siteVariables,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables, borderRadius: 0 });
 
     return {
       display: 'flex',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -182,12 +182,17 @@ export const menuItemStyles: ComponentSlotStylesPrepared<MenuItemStylesProps, Me
               ...(underlined && { fontWeight: 700 }),
               ...(underlined && active && underlinedItem(v.colorActive)),
             }),
-        ...((underlined || vertical) && {
+
+        ...(underlined && {
           ...getBorderFocusStyles({ variables: siteVariables }),
           ':focus-visible': {
             ...getBorderFocusStyles({ variables: siteVariables })[':focus-visible'],
             borderColor: v.borderColorActive,
           },
+        }),
+
+        ...(vertical && {
+          ...getBorderFocusStyles({ variables: siteVariables, borderRadius: 0 }),
         }),
       }),
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonStyles.ts
@@ -39,15 +39,7 @@ export const splitButtonStyles: ComponentSlotStylesPrepared<SplitButtonStylesPro
   }),
 
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: {
-        borderRadius: v.focusBorderRadius,
-        borderWidth: v.focusBorderWidth,
-        focusInnerBorderColor: v.focusInnerBorderColor,
-        focusOuterBorderColor: v.focusOuterBorderColor,
-        zIndexes: { foreground: v.focusBorderZIndex },
-      },
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables });
 
     return {
       borderRadius: v.borderRadius,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
@@ -23,16 +23,7 @@ export const splitButtonToggleStyles: ComponentSlotStylesPrepared<
     const { siteVariables } = theme;
     const { borderWidth } = siteVariables;
 
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: {
-        borderRadius: v.focusBorderRadius,
-        borderWidth: v.focusBorderWidth,
-        focusInnerBorderColor: v.focusInnerBorderColor,
-        focusOuterBorderColor: v.focusOuterBorderColor,
-        zIndexes: { foreground: v.focusBorderZIndex },
-      },
-      borderPadding: borderWidth,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables, borderPadding: borderWidth });
 
     const toggleButtonColorHover = () => (p.primary ? v.toggleButtonPrimaryHoverColor : v.toggleButtonColorHover);
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonVariables.ts
@@ -48,12 +48,6 @@ export interface SplitButtonVariables {
   toggleButtonBackgroundColorDisabled: string;
 
   toggleButtonIndicatorSize: string;
-
-  focusBorderRadius: string;
-  focusBorderWidth: string;
-  focusInnerBorderColor: string;
-  focusOuterBorderColor: string;
-  focusBorderZIndex: string;
 }
 
 export const splitButtonVariables = (siteVars: SiteVariablesPrepared): SplitButtonVariables => {
@@ -103,11 +97,5 @@ export const splitButtonVariables = (siteVars: SiteVariablesPrepared): SplitButt
     toggleButtonBackgroundColorDisabled: siteVars.colorScheme.default.backgroundDisabled,
 
     toggleButtonIndicatorSize: pxToRem(16),
-
-    focusBorderRadius: siteVars.borderRadiusMedium,
-    focusBorderWidth: siteVars.borderWidth,
-    focusInnerBorderColor: siteVars.focusInnerBorderColor,
-    focusOuterBorderColor: siteVars.focusOuterBorderColor,
-    focusBorderZIndex: siteVars.zIndexes.foreground,
   };
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableCellStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableCellStyles.ts
@@ -5,9 +5,7 @@ import { getBorderFocusStyles } from '../../getBorderFocusStyles';
 
 export const tableCellStyles: ComponentSlotStylesPrepared<TableCellStylesProps, TableVariables> = {
   root: ({ variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: siteVariables,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables, borderRadius: 0 });
 
     return {
       display: 'flex',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableRowStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableRowStyles.ts
@@ -5,9 +5,7 @@ import { getBorderFocusStyles } from '../../getBorderFocusStyles';
 
 export const tableRowStyles: ComponentSlotStylesPrepared<TableRowStylesProps, TableVariables> = {
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: siteVariables,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables, borderRadius: 0 });
 
     return {
       display: 'flex',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
@@ -9,9 +9,7 @@ export const toolbarItemStyles: ComponentSlotStylesPrepared<ToolbarItemStylesPro
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
     const colors = getColorScheme(v.colorScheme);
     const { borderWidth } = siteVariables;
-    const borderFocusStyles = getBorderFocusStyles({
-      variables: siteVariables,
-    });
+    const borderFocusStyles = getBorderFocusStyles({ variables: siteVariables });
 
     return {
       position: 'relative',

--- a/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
@@ -16,6 +16,7 @@ export const borderRadiusMedium = '4px'; // default border radius
 export const borderRadiusXLarge = '8px'; // X Large Border Radius
 export const focusInnerBorderColor = colors.white;
 export const focusOuterBorderColor = colors.black;
+export const focusBorderRadius = borderRadiusMedium;
 
 //
 // SHADOW LEVELS


### PR DESCRIPTION
Set the border radius of the focus border to `mediumBorderRadius`, i.e. `4px`.

The following components don't use that default but use `0` instead.
  - DropDownItem
  - ListItem
  - MenuItem (vertical only)
  - TableRow
  - TableCell
  - ToolbarMenuItem

This PR changes these Components:
- Checkbox: 3px -> 4px
- DropdownSelectedItem: 0 -> 4px
- MenuItem (iconOnly and underlined): 0 -> 4px
- Pill: 0 -> 4px
- RadioGroupItem: 0 -> 4px
- TreeItem: 0 -> 4px
- ToolbarItem: 0-> 4px