### PR TITLE
Semibold Author in compact ChatMessages

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -46,7 +46,7 @@ export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
   authorColor: siteVars.colorScheme.default.foreground,
   authorColorMineCompact: siteVars.colorScheme.brand.foreground,
   authorFontWeight: siteVars.fontWeightSemibold,
-  authorFontWeightCompact: siteVars.fontWeightBold,
+  authorFontWeightCompact: siteVars.fontWeightSemibold,
   authorMarginRight: pxToRem(12),
   authorMarginRightCompact: pxToRem(8),
   backgroundColor: siteVars.colorScheme.default.background,


### PR DESCRIPTION
Before: Bold
![Compact Author Before](https://user-images.githubusercontent.com/2564094/126824444-717ed87d-a501-4a70-8784-beb8879d9f44.png)

After: Semi-bold
![Compact Author After](https://user-images.githubusercontent.com/2564094/126824440-14ac78af-2b91-4af7-ac07-52e5897dfc26.png)
